### PR TITLE
Use remote master branch to compare in release process.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,7 @@ Install develop version ::
 
     cd /path/to/dir
     git clone git://github.com/koichiro/git-daily.git
+    cd git-daily
     rake build
     gem install pkg/git-daily-X.X.X.gem
 

--- a/lib/git-daily/command/release.rb
+++ b/lib/git-daily/command/release.rb
@@ -288,7 +288,13 @@ module Git
         end
 
         current_branch = Command.current_branch
-        master_branch = Command.master
+
+        remote = Command.remote
+        master_branch = if remote
+                          Command.remote_branch(remote, Command.master)
+                        else
+                          Command.master
+                        end
 
         puts "first, fetch remotes"
         `git fetch --all`

--- a/lib/git-daily/command/release.rb
+++ b/lib/git-daily/command/release.rb
@@ -47,7 +47,7 @@ module Git
 
         rel_branches = Command.release_branches(@branch_prefix)
         unless rel_branches.empty?
-          raise "release process (on local) is not closed, so cannot open relase\n    release branches: #{rel_branches.join(',')}"
+          raise "release process (on local) is not closed, so cannot open release\n    release branches: #{rel_branches.join(',')}"
         end
 
         remote = Command.remote
@@ -57,7 +57,7 @@ module Git
 
           rels = `git branch -a --no-color`.split(/\n/).select { |b| b[/remotes\/#{remote}\/#{@branch_prefix}/]}
           unless rels.empty?
-            raise "relase process (on local) is not closed, so cannot open releas\n    relase branchs: #{rels.join(',')}"
+            raise "release process (on local) is not closed, so cannot open release\n    release branches: #{rels.join(',')}"
           end
         end
 
@@ -237,7 +237,7 @@ module Git
             end
 
             if r_rel_branch != rel
-              $stderr.puts "Closed old relase branch"
+              $stderr.puts "Closed old release branch"
               $stderr.puts "Please retry 'release sync'"
             end
             puts "sync to release close"

--- a/test/test_command_release.rb
+++ b/test/test_command_release.rb
@@ -9,7 +9,7 @@ class TestCommandRelease < Test::Unit::TestCase
     @command = Git::Daily::Release.new
   end
 
-  def test_relase_open
+  def test_release_open
     @command.open
   end
 


### PR DESCRIPTION
We can compare release branch only with **local** master branch in the current code.

Change:
if remote is set, we can compare with **remote** master branch.