### PR TITLE
Show pull requests' urls with release list command exection

### DIFF
--- a/lib/git-daily/command.rb
+++ b/lib/git-daily/command.rb
@@ -56,6 +56,12 @@ module Git
         r.empty? ? nil : r
       end
 
+      def self.pull_request_url
+        r = `git config gitdaily.pullRequestUrl`
+        r.chomp!
+        r.empty? ? nil : r
+      end
+
       def self.current_branch
         r = `git branch --no-color`.split(/\n/)
         master = r.select { |v| v[/^\*/] }

--- a/lib/git-daily/command/release.rb
+++ b/lib/git-daily/command/release.rb
@@ -369,6 +369,20 @@ module Git
             puts
           end
         end
+
+        if Command.pull_request_url
+          puts 'Pull Requests: '
+
+          urlBase = Command.pull_request_url
+          merges = `git log --merges --pretty=format:'%<(30)%s | %an' #{master_branch}..#{current_branch}`.split(/\n/)
+
+          merges.each do |merge|
+            merge.match(/^Merge pull request #(?<id>[1-9][0-9]*) .+$/) do |match|
+              url = sprintf(urlBase,  match[:id])
+              puts "\t#{url} | #{match[0]}"
+            end
+          end
+        end
       end
 
       def usage


### PR DESCRIPTION
I'd like to show pull requests urls in release list.

output sample:

```
$ git daily release list
first, fetch remotes
Commit list:
	2c1946b59ee67957c0640ebd9dd9b81562ffd5f2 = negito6
	19d41059d30e58c5f3e8c16757750f1d20f20a4a = matsubokkuri
	f5c1d52a41e1c8754dbad2d0ab34e29f0d978f19 = koichiro

Modified files:
	README.rst
	lib/git-daily/command.rb
	lib/git-daily/command/release.rb
	lib/git-daily/version.rb

Pull Requests: 
	https://github.com/koichiro/git-daily/pull/1 | Merge pull request #1 from matsubo/patch-1 | Koichiro Ohba
$
```