### PR TITLE
Feature/fix base branch

### DIFF
--- a/lib/git-daily/command/hotfix.rb
+++ b/lib/git-daily/command/hotfix.rb
@@ -7,9 +7,9 @@ module Git
     class Hotfix < Release
 
       def initialize
-        @base_branch = "master"
-        @merge_to = ["master", "develop", "release"]
+        @base_branch = Command.master
         @branch_prefix = 'hotfix'
+        @release_branch_prefix =  'release'
       end
 
       def help
@@ -17,11 +17,11 @@ module Git
       end
 
       def merge_branches
-        rel_branches = Command.release_branches("release")
+        rel_branches = Command.release_branches(@release_branch_prefix)
         if rel_branches.empty?
-          return ["master", "develop"]
+          return [@base_branch, Command.develop]
         else
-          return ["master", "release"]
+          return [@base_branch, @release_branch_prefix]
         end
       end
 

--- a/lib/git-daily/command/hotfix.rb
+++ b/lib/git-daily/command/hotfix.rb
@@ -19,9 +19,9 @@ module Git
       def merge_branches
         rel_branches = Command.release_branches(@release_branch_prefix)
         if rel_branches.empty?
-          return [@base_branch, Command.develop]
+          return [Command.master, Command.develop]
         else
-          return [@base_branch, @release_branch_prefix]
+          return [Command.master, @release_branch_prefix]
         end
       end
 

--- a/lib/git-daily/command/release.rb
+++ b/lib/git-daily/command/release.rb
@@ -14,9 +14,9 @@ module Git
       } unless const_defined? :SUBCOMMAND
 
       def initialize
-        @base_branch = "develop"
+        @base_branch = Command.develop
         @branch_prefix = "release"
-        @merge_to = ["master", "develop"]
+        @merge_to = [Command.master, Command.develop]
       end
 
       def help


### PR DESCRIPTION
Fixed problem that we can't use branches whose name were not master/develop as base branch.

Tested
* release open / close
* hotfix open / close without release branch
* hotfix open / close with release branch
